### PR TITLE
improve send_email mocks and fix home page content type for lighthouse runs (pg 223)

### DIFF
--- a/src/email_client.rs
+++ b/src/email_client.rs
@@ -68,7 +68,7 @@ mod tests {
     use fake::faker::lorem::en::{Paragraph, Sentence};
     use fake::{Fake, Faker};
     use secrecy::Secret;
-    use wiremock::matchers::any;
+    use wiremock::matchers::{header, header_exists, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[tokio::test]
@@ -76,7 +76,10 @@ mod tests {
         let mock_server = MockServer::start().await;
         let sender = SubscriberEmail::parse(SafeEmail().fake()).unwrap();
         let email_client = EmailClient::new(mock_server.uri(), sender, Secret::new(Faker.fake()));
-        Mock::given(any())
+        Mock::given(header_exists("X-Postmark-Server-Token"))
+            .and(header("Content-Type", "application/json"))
+            .and(path("/email"))
+            .and(method("POST"))
             .respond_with(ResponseTemplate::new(200))
             .expect(1)
             .mount(&mock_server)

--- a/src/root.rs
+++ b/src/root.rs
@@ -1,10 +1,17 @@
 use crate::email_client::EmailClient;
 use crate::routes::{health_check, subscribe};
 use actix_web::dev::Server;
-use actix_web::{web, App, HttpServer};
+use actix_web::http::StatusCode;
+use actix_web::{web, App, HttpResponse, HttpServer};
 use sqlx::PgPool;
 use std::net::TcpListener;
 use tracing_actix_web::TracingLogger;
+
+pub async fn home_page() -> HttpResponse {
+    HttpResponse::build(StatusCode::OK)
+        .content_type("text/html; charset=utf-8")
+        .body("<h1>hello from home page</h1>")
+}
 
 pub fn run(
     listener: TcpListener,
@@ -15,7 +22,7 @@ pub fn run(
     let server = HttpServer::new(move || {
         App::new()
             .wrap(TracingLogger::default())
-            .route("/", web::get().to(|| async { "hello from home page" }))
+            .route("/", web::get().to(home_page))
             .route("/health_check", web::get().to(health_check))
             .route("/subscriptions", web::post().to(subscribe))
             .app_data(db_pool.clone())


### PR DESCRIPTION
<img width="553" alt="Screen Shot 2022-05-08 at 6 23 45 PM" src="https://user-images.githubusercontent.com/23511462/167322013-192bbbf1-43f0-4290-967a-f352983022d3.png">
